### PR TITLE
Add coverage testing and reporting to SonarQube Cloud

### DIFF
--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -76,6 +76,11 @@ jobs:
                     pypi_username: ${{secrets.TEST_PYPI_USERNAME}}
                     pypi_password: ${{secrets.TEST_PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+            -
+                name: 🛏️ Upload Coverage
+                uses: SonarSource/sonarqube-scan-action@v5
+                env:
+                        SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
 
 ...
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pip-selfcheck.json
 
 # Python testing artifacts
 .coverage
+coverage.xml
 htmlcov
 .tox/
 

--- a/docs/requirements/v2.4.0-dev/REQUIREMENTS.md
+++ b/docs/requirements/v2.4.0-dev/REQUIREMENTS.md
@@ -4,47 +4,47 @@ Requirements Summary
 
 # default
 
-## As a manager, I want to know the current total volume of PDS holdings ([#2](https://github.com/NASA-PDS/registry-dashboards/issues/2)) 
+## As a manager, I want to know the current total volume of PDS holdings ([#2](https://github.com/NASA-PDS/registry-dashboards/issues/2))
 
 
 This requirement is not impacted by the current version
-## As a PDS Project Office, I want to know the historical total volume of PDS holdings over time ([#7](https://github.com/NASA-PDS/registry-dashboards/issues/7)) 
+## As a PDS Project Office, I want to know the historical total volume of PDS holdings over time ([#7](https://github.com/NASA-PDS/registry-dashboards/issues/7))
 
 
 This requirement is not impacted by the current version
-## As a Node Manager, I want to create archive storage profiles of data volumes ([#8](https://github.com/NASA-PDS/registry-dashboards/issues/8)) 
+## As a Node Manager, I want to create archive storage profiles of data volumes ([#8](https://github.com/NASA-PDS/registry-dashboards/issues/8))
 
 
 This requirement is not impacted by the current version
-## As a Node Manager, I want to have separate views of data holdings for PDS ([#9](https://github.com/NASA-PDS/registry-dashboards/issues/9)) 
+## As a Node Manager, I want to have separate views of data holdings for PDS ([#9](https://github.com/NASA-PDS/registry-dashboards/issues/9))
 
 
 This requirement is not impacted by the current version
-## As a Node Manager, I want to report on the number of artifacts within the archive ([#10](https://github.com/NASA-PDS/registry-dashboards/issues/10)) 
+## As a Node Manager, I want to report on the number of artifacts within the archive ([#10](https://github.com/NASA-PDS/registry-dashboards/issues/10))
 
 
 This requirement is not impacted by the current version
-## As a Node Manager, I want to report to missions that request volume information ([#11](https://github.com/NASA-PDS/registry-dashboards/issues/11)) 
+## As a Node Manager, I want to report to missions that request volume information ([#11](https://github.com/NASA-PDS/registry-dashboards/issues/11))
 
 
 This requirement is not impacted by the current version
-## As a Node Manager, I want to customize new reports on volume metrics ([#12](https://github.com/NASA-PDS/registry-dashboards/issues/12)) 
+## As a Node Manager, I want to customize new reports on volume metrics ([#12](https://github.com/NASA-PDS/registry-dashboards/issues/12))
 
 
 This requirement is not impacted by the current version
-## As a Node Manager, I want to know the projected total volume of Node holdings over time ([#13](https://github.com/NASA-PDS/registry-dashboards/issues/13)) 
+## As a Node Manager, I want to know the projected total volume of Node holdings over time ([#13](https://github.com/NASA-PDS/registry-dashboards/issues/13))
 
 
 This requirement is not impacted by the current version
-## As a DDWG Representative,  I want to find the uses ([#15](https://github.com/NASA-PDS/registry-dashboards/issues/15)) 
+## As a DDWG Representative,  I want to find the uses ([#15](https://github.com/NASA-PDS/registry-dashboards/issues/15))
 
 
 This requirement is not impacted by the current version
-## As a PDS manager, I want to see the ingestion status in the registry ([#29](https://github.com/NASA-PDS/registry-dashboards/issues/29)) 
+## As a PDS manager, I want to see the ingestion status in the registry ([#29](https://github.com/NASA-PDS/registry-dashboards/issues/29))
 
 
 This requirement is not impacted by the current version
-## As a Node person I want to add a new bundle metrics visualization to the dashboard ([#30](https://github.com/NASA-PDS/registry-dashboards/issues/30)) 
+## As a Node person I want to add a new bundle metrics visualization to the dashboard ([#30](https://github.com/NASA-PDS/registry-dashboards/issues/30))
 
 
 This requirement is not impacted by the current version

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.projectKey=NASA-PDS_registry-dashboards
+sonar.organization=nasa-pds
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,42 @@
 [tox]
 envlist = py313, docs, lint
-
+requires = tox>=4.6
 
 [testenv]
-deps = .[dev]
-whitelist_externals = pytest
-commands = pytest
-
+description = run tests
+basepython = python3.13
+package = wheel
+extras = dev
+usedevelop = true
+commands = pytest --cov=src --cov-report=xml {posargs}
 
 [testenv:docs]
-deps = .[dev]
-whitelist_externals = python
+description = build docs
+extras = dev
 commands = sphinx-build -b html docs/source docs/build
 
-
 [testenv:lint]
-deps = pre-commit
-commands=
-    python -m pre_commit run --color=always {posargs:--all}
+description = run linters
 skip_install = true
+deps = pre-commit
+commands = python -m pre_commit run --color=always {posargs:--all}
 
+[coverage:run]
+source = src
+omit =
+    */tests/*
+    */test_*
+    */__pycache__/*
 
-[testenv:dev]
-basepython = python3.13
-usedevelop = True
-deps = .[dev]
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod


### PR DESCRIPTION
## 🗒️ Summary

- Merge to add coverage testing and reporting to SonarQube Cloud
- Also the end-of-file-fixer fixed the end-of-file in `REQUIREMENTS.md` thanks end-of-file-fixer


## ⚙️ Test Data and/or Report

```console
(.venv) bash-3.2$ ls -l coverage.xml 
-rw-r--r--  1 kelly  staff  1242 Oct  4 10:32 coverage.xml
(.venv) bash-3.2$ file coverage.xml 
coverage.xml: XML 1.0 document text, ASCII text
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/104